### PR TITLE
feat: add means to produce compile_commands for msvc

### DIFF
--- a/toolchain.msvc.lua
+++ b/toolchain.msvc.lua
@@ -19,9 +19,7 @@ function CONFIG:cxx(inputs)
 		-- /Fd is a rather clunky way of overriding vc140.pdb, but we'd really
 		-- like to avoid that ghost node, which causes a second unnecessary
 		-- link pass if tup is launched immediately after a successful build.
-		local cmd = (
-			'cl /nologo /c /Qpar /Zi /Fo:"%o" /Fd:"%O.pdb"' .. flags .. ' "%f"'
-		)
+		local cmd = ('^j^ cl /nologo /c /Qpar /Zi /Fo:"%o" /Fd:"%O.pdb"' .. flags .. ' "%f"')
 		local ret = tup.foreach_rule(vars.cinputs, cmd, vars.coutputs)
 		for _, fn in ipairs(ret) do
 			ret.extra_inputs += string.gsub(fn, ".obj$", ".pdb")


### PR DESCRIPTION
clangd depends on a file compile_commands describing the codebase to provide lsp support. Tup provides the command compiledb to produce it. Files that should be added to the database have to be annotated with a ^j. This commit adds the annotation for msvc toolchains.